### PR TITLE
Undefined variable $im when editing plugin

### DIFF
--- a/app/administrator/modules/mod_menu/tmpl/default_disabled.php
+++ b/app/administrator/modules/mod_menu/tmpl/default_disabled.php
@@ -51,7 +51,7 @@ $pm = $user->authorise('core.manage', 'com_plugins');
 $tm = $user->authorise('core.manage', 'com_templates');
 $lm = $user->authorise('core.manage', 'com_languages');
 
-if ($im || $mm || $pm || $tm || $lm)
+if ($mm || $pm || $tm || $lm)
 {
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_EXTENSIONS'), null, 'disabled'));
 }


### PR DESCRIPTION
$im is a leftover variable when this line was removed:

`$im = $user->authorise('core.manage', 'com_installer');`

See SHA: 44f6d872981ecf98a9793cfc402fac399432e39a

Resolves #242 